### PR TITLE
Fixing a typo in escaping the string

### DIFF
--- a/latex/__init__.py
+++ b/latex/__init__.py
@@ -20,7 +20,7 @@ CHAR_ESCAPE = {
     u'<': u'\\textless{}',
     u'>': u'\\textgreater{}',
     u'|': u'\\textbar{}',
-    u'"': u'\\textquoteddbl{}',
+    u'"': u'\\textquotedbl{}',
 }
 
 


### PR DESCRIPTION
Changed typo LaTeX syntax definition - `\textquoteddbl{}` should be `\textquotedbl{}`