### PR TITLE
Added escaping of a degree character (°)

### DIFF
--- a/latex/__init__.py
+++ b/latex/__init__.py
@@ -21,6 +21,7 @@ CHAR_ESCAPE = {
     u'>': u'\\textgreater{}',
     u'|': u'\\textbar{}',
     u'"': u'\\textquotedbl{}',
+    u'°': u'$\\deg$',
 }
 
 


### PR DESCRIPTION
It seems that on some platforms and different LaTeX versions this has to be escaped.