### PR TITLE
 Support for passing arguments to escape from jinja2 templates. 

### DIFF
--- a/latex/jinja2.py
+++ b/latex/jinja2.py
@@ -14,11 +14,11 @@ class LatexMarkup(Markup):
         raise NotImplementedError
 
     @classmethod
-    def escape(cls, s):
+    def escape(cls, s, *args, **kwargs):
         if hasattr(s, '__html__'):
             return s.__html__()
 
-        rv = escape(s)
+        rv = escape(s, *args, **kwargs)
         if rv.__class__ is not cls:
             return cls(rv)
         return rv

--- a/tests/test_jinja2.py
+++ b/tests/test_jinja2.py
@@ -1,0 +1,35 @@
+from latex.jinja2 import make_env
+from jinja2.loaders import DictLoader
+
+
+def test_jinja2_var():
+    in_template = r'Hello \VAR{name}!'
+    out = r'Hello Eric!'
+
+    env = make_env(loader=DictLoader({"template.tex": in_template}))
+    template = env.get_template("template.tex")
+    assert out == template.render(name="Eric")
+
+
+def test_jinja2_escape():
+    in_template = r'Hello \VAR{name | e}!'
+    out = r'Hello Jo\%h\%n\textasciitilde{} \textbackslash{}emph\{Cle\%ese\}\$!'
+    env = make_env(loader=DictLoader({'template.tex': in_template}))
+    template = env.get_template('template.tex')
+    assert out == template.render(name=r'Jo%h%n~ \emph{Cle%ese}$')
+
+
+def test_jinja2_newline_escape():
+    in_template = r'Hello \VAR{name | e}!'
+    out = r'Hello Michael \\Palin!'
+    env = make_env(loader=DictLoader({'template.tex': in_template}))
+    template = env.get_template('template.tex')
+    assert out == template.render(name='Michael \n\n\nPalin')
+
+
+def test_jinja2_newline_escape_no_folding():
+    in_template = r'Hello \VAR{name | e(fold_newlines=false)}!'
+    out = r'Hello Michael \\[3\baselineskip]Palin!'
+    env = make_env(loader=DictLoader({'template.tex': in_template}))
+    template = env.get_template('template.tex')
+    assert out == template.render(name='Michael \n\n\nPalin')


### PR DESCRIPTION
Added the ability to pass arguments to escape from a jinja2 template.

It's not a big deal, but would be nice to be able to specify fold_newlines within jinja2.

The tests require jinja2 to pass (which isn't currently listed as a dependency).