### PR TITLE
Add markupsafe to install_requires.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     url='http://github.com/mbr/latex',
     license='MIT',
     packages=find_packages(exclude=['tests']),
-    install_requires=['tempdir', 'data', 'future', 'shutilwhich', 'markupsafe', 'jinja2'],
+    install_requires=['tempdir', 'data', 'future', 'shutilwhich', 'jinja2'],
     classifiers=[
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     url='http://github.com/mbr/latex',
     license='MIT',
     packages=find_packages(exclude=['tests']),
-    install_requires=['tempdir', 'data', 'future', 'shutilwhich'],
+    install_requires=['tempdir', 'data', 'future', 'shutilwhich', 'markupsafe'],
     classifiers=[
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     url='http://github.com/mbr/latex',
     license='MIT',
     packages=find_packages(exclude=['tests']),
-    install_requires=['tempdir', 'data', 'future', 'shutilwhich', 'markupsafe'],
+    install_requires=['tempdir', 'data', 'future', 'shutilwhich', 'markupsafe', 'jinja2'],
     classifiers=[
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
https://github.com/mbr/latex/blob/master/latex/jinja2.py requires markupsafe and jinja2, but these are not currently listed in install_requires (with the result that it crashes when latex.jinja2 is used).