### PR TITLE
Capture LaTeX build errors

### DIFF
--- a/latex/build.py
+++ b/latex/build.py
@@ -103,13 +103,15 @@ class LatexMkBuilder(LatexBuilder):
             newenv['TEXINPUTS'] = os.pathsep.join(texinputs) + os.pathsep
 
             try:
-                subprocess.check_call(args,
-                                      cwd=tmpdir,
-                                      env=newenv,
-                                      stdin=open(os.devnull, 'r'),
-                                      stdout=open(os.devnull, 'w'),
-                                      stderr=open(os.devnull, 'w'), )
+                subprocess.run(args,
+                               cwd=tmpdir,
+                               check=True,
+                               env=newenv,
+                               capture_output=True,
+                              )
             except CalledProcessError as e:
+                assert not e.stdout
+                print(e.stderr)
                 raise_from(LatexBuildError(base_fn + '.log'), e)
 
             return I(open(output_fn, 'rb').read(), encoding=None)

--- a/latex/build.py
+++ b/latex/build.py
@@ -110,7 +110,7 @@ class LatexMkBuilder(LatexBuilder):
                                capture_output=True,
                               )
             except CalledProcessError as e:
-                assert not e.stdout
+                print(e.stdout)
                 print(e.stderr)
                 raise_from(LatexBuildError(base_fn + '.log'), e)
 


### PR DESCRIPTION
Unless I'm missing something, at present there is no way to view LaTeX build errors if there are any.
It's easy enough to capture the stderr from the call, but I'm not sure what would be the best way to integrate it into the LatexBuildError object.