### PR TITLE
Use forward slashes in file paths on windows

### DIFF
--- a/latex/build.py
+++ b/latex/build.py
@@ -89,7 +89,7 @@ class LatexMkBuilder(LatexBuilder):
                 args = [self.latexmk,
                         '-pdf',
                         '-pdflatex={}'.format(' '.join(latex_cmd)),
-                        tmp.name, ]
+                        tmp.name.replace('\\', '/'), ]
             elif self.variant == 'xelatex':
                 args = [self.latexmk,
                         '-xelatex',

--- a/latex/build.py
+++ b/latex/build.py
@@ -103,13 +103,15 @@ class LatexMkBuilder(LatexBuilder):
             newenv['TEXINPUTS'] = os.pathsep.join(texinputs) + os.pathsep
 
             try:
-                subprocess.check_call(args,
-                                      cwd=tmpdir,
-                                      env=newenv,
-                                      stdin=open(os.devnull, 'r'),
-                                      stdout=open(os.devnull, 'w'),
-                                      stderr=open(os.devnull, 'w'), )
+                subprocess.run(args,
+                               cwd=tmpdir,
+                               check=True,
+                               env=newenv,
+                               capture_output=True,
+                              )
             except CalledProcessError as e:
+                assert not e.stdout
+                print(e.stderr)
                 raise_from(LatexBuildError(base_fn + '.log'), e)
 
             return I(open(output_fn, 'rb').read(), encoding=None)

--- a/latex/build.py
+++ b/latex/build.py
@@ -110,7 +110,7 @@ class LatexMkBuilder(LatexBuilder):
                                capture_output=True,
                               )
             except CalledProcessError as e:
-                assert not e.stdout
+                print(e.stdout)
                 print(e.stderr)
                 raise_from(LatexBuildError(base_fn + '.log'), e)
 


### PR DESCRIPTION
Windows accepts forward-slashes, and latexmk does not accept backslashes.
Right now this only changes it for pdflatex, but we can do it for the others too.