### PR TITLE
Fix escape for undefined variables

### DIFF
--- a/latex/jinja2.py
+++ b/latex/jinja2.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 from markupsafe import Markup
 from jinja2 import Environment
+from jinja2.runtime import Undefined
 
 from . import escape
 
@@ -15,6 +16,8 @@ class LatexMarkup(Markup):
 
     @classmethod
     def escape(cls, s):
+        if isinstance(s, Undefined):
+            return s
         if hasattr(s, '__html__'):
             return s.__html__()
 


### PR DESCRIPTION
If the escape filter is used for an undefined variable (e.g. `r'\VAR{foo|e}'` with `template.render()`), [latex.escape:61](https://github.com/mbr/latex/blob/f96cb9125b4f570fc2ffc5ae628e2f4069b2f3cf/latex/__init__.py#L61) will raise an error: `TypeError: expected string or bytes-like object`. This PR should fix it.