### PR TITLE
Make use of the relative path when call the process.

### DIFF
--- a/latex/build.py
+++ b/latex/build.py
@@ -89,11 +89,11 @@ class LatexMkBuilder(LatexBuilder):
                 args = [self.latexmk,
                         '-pdf',
                         '-pdflatex={}'.format(' '.join(latex_cmd)),
-                        tmp.name, ]
+                        os.path.basename(tmp.name), ]
             elif self.variant == 'xelatex':
                 args = [self.latexmk,
                         '-xelatex',
-                        tmp.name, ]
+                        os.path.basename(tmp.name), ]
             else:
                 raise ValueError('Invalid LaTeX variant: {}'.format(
                     self.variant))
@@ -157,7 +157,7 @@ class PdfLatexBuilder(LatexBuilder):
             output_fn = base_fn + '.pdf'
             aux_fn = base_fn + '.aux'
             args = [self.pdflatex, '-interaction=batchmode', '-halt-on-error',
-                    '-no-shell-escape', '-file-line-error', tmp.name]
+                    '-no-shell-escape', '-file-line-error', os.path.basename(tmp.name)]
 
             # create environment
             newenv = os.environ.copy()


### PR DESCRIPTION
This PR Fix #32.

Trying to execute the command in the console without `-interaction=batchmode` pdflatex say that the file does not exist.
I noticed that in Windows 2016 the temp path of the latex file is composed by the compressed username "ADMINI~1" and not the real one "Administrator":
```
'['pdflatex', '-interaction=batchmode', '-halt-on-error', '-no-shell-escape', '-file-line-error', 'C:\\Users\\ADMINI~1\\AppData\\Local\\Temp\\3\\tmptebd6l1k\\tmptnlokmm8.latex']'
```
Using pdflatex in the console with "Administrator" instead of "ADMINI~1" the file is seen by pdflatex.
Probably the function that get the tempfiles in Windows 2016 is the real source of the problem here, but I have found another solution: make use of the relative path filename instead of the absolute one.

In fact the current directory of the commands is set to the temp directory and I do not see any contraindication to leave just the relative path (just the filename) starting from the tempdir: 

 ```
 ['pdflatex', '-interaction=batchmode', '-halt-on-error', '-no-shell-escape', '-file-line-error', 'tmptnlokmm8.latex']
```

This solve my problem.